### PR TITLE
Ready to ship

### DIFF
--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -21,7 +21,7 @@ class Merchant < ApplicationRecord
   end
 
   def ready_to_ship
-    invoice_items.joins(:invoice).where.not(status: 2).order(:created_at)
+    invoice_items.joins(:invoice).where.not(status: 2).order('invoices.created_at')
   end
 
 

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -21,6 +21,7 @@ class Merchant < ApplicationRecord
   end
 
   def ready_to_ship
+    # require 'pry'; binding.pry
     invoice_items.joins(:invoice).where.not(status: 2).order('invoices.created_at')
   end
 

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -20,8 +20,8 @@ class Merchant < ApplicationRecord
               .limit(5)
   end
 
-  def items_ready_to_ship
-    items.joins(:invoice_items).where.not(invoice_items: {status: 2})
+  def ready_to_ship
+    invoice_items.joins(:invoice).where.not(status: 2).order(:created_at)
   end
 
 

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -21,13 +21,11 @@
 <section id="items_ready_to_ship">
   <h3>Items Ready to Ship</h3>
   <ul>
-  <% @merchant.items_ready_to_ship.each do |item| %>
-    <div id="item-<%= item.id %>">
-    <% item.invoices.each do |invoice| %>
-      <%= item.name %>
-      <li><%= link_to "Invoice ##{invoice.id}", "/merchants/#{@merchant.id}/invoices/#{invoice.id}" %></li>
-      <li><%= invoice.formatted_created_at %>
-      <% end %>
+  <% @merchant.ready_to_ship.each do |invoice_item| %>
+    <div id="invoice-item-<%= invoice_item.id %>">
+      <%= invoice_item.item.name %>
+      <li><%= link_to "Invoice ##{invoice_item.invoice.id}", "/merchants/#{@merchant.id}/invoices/#{invoice_item.invoice.id}" %></li>
+      <li><%= invoice_item.invoice.formatted_created_at %>
   <% end %>
   </ul>
 </section>

--- a/spec/features/merchants/dashboard_spec.rb
+++ b/spec/features/merchants/dashboard_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe 'Merchant Dashboard Page' do
       expect(current_path).to eq("/merchants/#{merchant_1.id}/invoices/#{invoice.id}")
     end
     
-    xit "displays created_at date for each invoice in 'Ready to Ship' and they are ordered oldest to newest" do
+    it "displays created_at date for each invoice in 'Ready to Ship' and they are ordered oldest to newest" do
       merchant_1 = create(:merchant)
       
       item_1 = create(:item, merchant_id: merchant_1.id)

--- a/spec/features/merchants/dashboard_spec.rb
+++ b/spec/features/merchants/dashboard_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe 'Merchant Dashboard Page' do
         expect(page).to_not have_content(item_2.name)
       end
       
-      within "#item-#{item_1.id}" do
+      within "#invoice-item-#{invoice_item_1.id}" do
         expect(page).to have_content(item_1.name)
         expect(page).to have_link("#{invoice.id}")
       end
@@ -115,17 +115,18 @@ RSpec.describe 'Merchant Dashboard Page' do
       
       visit "/merchants/#{merchant_1.id}/dashboard"
       
-      within "#item-#{item_1.id}" do
+      within "#invoice-item-#{invoice_item_1.id}" do
         expect(page).to have_content("February 8, 2015")
       end
-      within "#item-#{item_2.id}" do
+      within "#invoice-item-#{invoice_item_2.id}" do
         expect(page).to have_content("February 21, 2020")
       end
-      within "#item-#{item_3.id}" do
+      within "#invoice-item-#{invoice_item_3.id}" do
         expect(page).to have_content("March 12, 2018")
       end
-      expect(item_2).to appear_before(item_3)
-      expect(item_3).to appear_before(item_1)
+      # save_and_open_page
+      expect(item_1.name).to appear_before(item_3.name)
+      expect(item_3.name).to appear_before(item_2.name)
     end
     #     As a merchant
     # When I visit my merchant dashboard

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Merchant, type: :model do
       expect(merch1.unique_invoices).to eq([invoice1, invoice2, invoice3])
     end
 
-    xit "#items_ready_to_ship" do
+    it "#items_ready_to_ship" do
       merchant_1 = create(:merchant)
       item_1 = create(:item, merchant_id: merchant_1.id)
       item_2 = create(:item, merchant_id: merchant_1.id)
@@ -84,7 +84,9 @@ RSpec.describe Merchant, type: :model do
       invoice_item_2 = create(:invoice_item, status: 0, item_id: item_1.id, invoice_id: invoice.id, created_at: date_2)
       invoice_item_3 = create(:invoice_item, status: 0, item_id: item_1.id, invoice_id: invoice.id, created_at: date_3)
 
-      expect(merchant_1.ready_to_ship).to eq([invoice_item_1, invoice_item_3, invoice_item_2])
+      expect(merchant_1.ready_to_ship[0]).to eq(invoice_item_1)
+      expect(merchant_1.ready_to_ship[1]).to eq(invoice_item_2)
+      expect(merchant_1.ready_to_ship[2]).to eq(invoice_item_3)
     end
     it '#current_invoice_items returns a merchants invoice items for a given invoice' do
       merch1 = FactoryBot.create(:merchant)

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -71,16 +71,20 @@ RSpec.describe Merchant, type: :model do
       expect(merch1.unique_invoices).to eq([invoice1, invoice2, invoice3])
     end
 
-    it "#items_ready_to_ship" do
+    xit "#items_ready_to_ship" do
       merchant_1 = create(:merchant)
       item_1 = create(:item, merchant_id: merchant_1.id)
       item_2 = create(:item, merchant_id: merchant_1.id)
       customer = create(:customer)
       invoice = create(:invoice, customer_id: customer.id, status: 1)
-      invoice_item_1 = create(:invoice_item, status: 0, item_id: item_1.id, invoice_id: invoice.id)
-      invoice_item_2 = create(:invoice_item, status: 2, item_id: item_2.id, invoice_id: invoice.id)
+      date_1 = 	"2015-02-08 09:54:09 UTC".to_datetime
+      date_2 = 	"2020-02-21 09:54:09 UTC".to_datetime
+      date_3 = 	"2018-03-12 09:54:09 UTC".to_datetime
+      invoice_item_1 = create(:invoice_item, status: 0, item_id: item_1.id, invoice_id: invoice.id, created_at: date_1)
+      invoice_item_2 = create(:invoice_item, status: 0, item_id: item_1.id, invoice_id: invoice.id, created_at: date_2)
+      invoice_item_3 = create(:invoice_item, status: 0, item_id: item_1.id, invoice_id: invoice.id, created_at: date_3)
 
-      expect(merchant_1.items_ready_to_ship).to eq([item_1])
+      expect(merchant_1.ready_to_ship).to eq([invoice_item_1, invoice_item_3, invoice_item_2])
     end
     it '#current_invoice_items returns a merchants invoice items for a given invoice' do
       merch1 = FactoryBot.create(:merchant)


### PR DESCRIPTION
 - merchant#ready_to_ship returns invoice items that are not yet shipped, and orders them in order from oldest to newest by the created_at date of the invoice they're associated with
 - views take the invoice items and format the data to match the wireframe specs, including formatting datetime information from UTC into "weekday, month, day, year"