### PR TITLE
Merchants by status

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -2,6 +2,8 @@ class Admin::MerchantsController < ApplicationController
 
   def index
     @merchants = Merchant.all
+    @enabled = @merchants.status_enabled
+    @disabled = @merchants.status_disabled
   end
 
   def show
@@ -31,5 +33,5 @@ class Admin::MerchantsController < ApplicationController
     private
       def merchant_params
         params.permit(:id, :name, :status)
-    end 
+    end
 end

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -24,13 +24,12 @@ class Admin::MerchantsController < ApplicationController
   end
 
   def update
-    # require "pry"; binding.pry
     @merchant = Merchant.find(params[:id])
     @merchant.update(merchant_params)
     if @merchant.save
       flash[:notice] = "Update Succesful!"
       redirect_to "/admin/merchants/#{@merchant.id}"
-    end 
+    end
   end
 
 

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -24,9 +24,13 @@ class Admin::MerchantsController < ApplicationController
   end
 
   def update
+    # require "pry"; binding.pry
     @merchant = Merchant.find(params[:id])
     @merchant.update(merchant_params)
-    @merchant.save
+    if @merchant.save
+      flash[:notice] = "Update Succesful!"
+      redirect_to "/admin/merchants/#{@merchant.id}"
+    end 
   end
 
 

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -38,6 +38,9 @@ class Merchant < ApplicationRecord
   def total_revenue_for_invoice(invoice_id)
     invoice = Invoice.find(invoice_id)
     invoice.invoice_items.sum('unit_price * quantity') / 100.to_f
+  end
 
+  def self.status_enabled
+    where(status: 0)
   end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -8,7 +8,7 @@ class Merchant < ApplicationRecord
   validates_presence_of :name
   validates_presence_of :created_at
   validates_presence_of :updated_at
-  enum status: {enable: 0, disable: 1}
+  enum status: {enabled: 0, disabled: 1}
 
 
   def top_five_customers

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -43,4 +43,8 @@ class Merchant < ApplicationRecord
   def self.status_enabled
     where(status: 0)
   end
+
+  def self.status_disabled
+    where(status: 1)
+  end
 end

--- a/app/views/admin/merchants/edit.html.erb
+++ b/app/views/admin/merchants/edit.html.erb
@@ -1,0 +1,8 @@
+<h1>Update Merchant: </h1>
+
+<%= form_with url: "/admin/merchants/#{@merchant.id}", method: :patch, local: true do |f| %>
+  <%= f.label :name %>
+  <%= f.text_field :name, value: @merchant.name %>
+  <%= f.hidden_field :status, value: @merchant.status %>
+  <%= f.submit "Submit" %>
+<% end %>

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -8,7 +8,7 @@
 <% @enabled.each do |enabled_merchant| %>
 <section id="enabled_merchants-<%= enabled_merchant.id %>">
 
-  <%= enabled_merchant.name %><br>
+  <%= link_to "#{enabled_merchant.name}", "/admin/merchants/#{enabled_merchant.id}" %><br>
 
 </section>
 <% end %>
@@ -18,7 +18,11 @@
 
 <h3>Disabled Merchants</h3>
 <% @disabled.each do |disabled_merchant| %>
+
 <section id="disabled_merchants-<%= disabled_merchant.id %>">
-  <%= disabled_merchant.name %><br>
+
+  <%= link_to "#{disabled_merchant.name}", "/admin/merchants/#{disabled_merchant.id}" %><br>
+
+
 </section>
 <% end %>

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -1,1 +1,9 @@
 <h1>Admin Merchants</h1>
+
+<h4>All Merchants Currently In System</h4><br>
+
+<% @merchants.each do |merchant| %>
+
+  <%= merchant.name %> <br><br>
+
+<% end %>

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -3,7 +3,9 @@
 <h4>All Merchants Currently In System</h4><br>
 
 <% @merchants.each do |merchant| %>
+<section id="merchant-<%= merchant.id %>">
 
   <%= merchant.name %> <br><br>
 
+</section>
 <% end %>

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -1,11 +1,18 @@
 <h1>Admin Merchants</h1>
 
-<h4>All Merchants Currently In System</h4><br>
 
-<% @merchants.each do |merchant| %>
-<section id="merchant-<%= merchant.id %>">
 
-  <%= merchant.name %> <br><br>
-
-</section>
+<h3>Enabled Merchants</h3>
+<section id="enabled_merchants">
+<% @enabled.each do |enabled_merchant| %>
+  <%= enabled_merchant.name %><br>
 <% end %>
+</section>
+<br><br>
+
+<h3>Disabled Merchants</h3>
+<section id="disabled_merchants">
+<% @disabled.each do |disabled_merchant| %>
+  <%= disabled_merchant.name %><br>
+<% end %>
+</section>

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -3,16 +3,22 @@
 
 
 <h3>Enabled Merchants</h3>
-<section id="enabled_merchants">
+
+
 <% @enabled.each do |enabled_merchant| %>
+<section id="enabled_merchants-<%= enabled_merchant.id %>">
+
   <%= enabled_merchant.name %><br>
-<% end %>
+
 </section>
+<% end %>
+
+
 <br><br>
 
 <h3>Disabled Merchants</h3>
-<section id="disabled_merchants">
 <% @disabled.each do |disabled_merchant| %>
+<section id="disabled_merchants-<%= disabled_merchant.id %>">
   <%= disabled_merchant.name %><br>
-<% end %>
 </section>
+<% end %>

--- a/app/views/admin/merchants/show.html.erb
+++ b/app/views/admin/merchants/show.html.erb
@@ -1,3 +1,9 @@
 <h1>Admin Merchant Show Page</h1>
 
 <h3>Merchant Name: <%= @merchant.name %></h3>
+
+<h4>Update Merchant</h4>
+
+<section id="update_this_merchant">
+  <%= link_to "Update This Merchant", "/admin/merchants/#{@merchant.id}/edit" %>
+</section>

--- a/app/views/admin/merchants/show.html.erb
+++ b/app/views/admin/merchants/show.html.erb
@@ -1,0 +1,3 @@
+<h1>Admin Merchant Show Page</h1>
+
+<h3>Merchant Name: <%= @merchant.name %></h3>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,9 @@
   </head>
 
   <body>
+    <% flash.each do |type, message| %>
+     <p><%= message %></p>
+   <% end %>
     <%= yield %>
   </body>
 </html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
   get '/admin/merchants', to: 'admin/merchants#index'
   get '/admin/merchants/:id', to: 'admin/merchants#show'
   get '/admin/merchants/:id/edit', to: 'admin/merchants#edit'
+  patch '/admin/merchants/:id', to: 'admin/merchants#update'
 
   # get '/merchants/:id/invoices', to: 'merchant_invoices#index'
   get '/merchants/:merchant_id/invoices/:id', to: 'merchant_invoices#show'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
   get '/admin/merchants/:id/dashboard', to: "admin/dashboard#index"
 
   get '/admin', to: "admin/dashboard#index"
+  get '/admin/merchants', to: 'admin/merchants#index'
 
   # get '/merchants/:id/invoices', to: 'merchant_invoices#index'
   get '/merchants/:merchant_id/invoices/:id', to: 'merchant_invoices#show'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
 
   get '/admin', to: "admin/dashboard#index"
   get '/admin/merchants', to: 'admin/merchants#index'
+  get '/admin/merchants/:id', to: 'admin/merchants#show'
 
   # get '/merchants/:id/invoices', to: 'merchant_invoices#index'
   get '/merchants/:merchant_id/invoices/:id', to: 'merchant_invoices#show'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
   get '/admin', to: "admin/dashboard#index"
   get '/admin/merchants', to: 'admin/merchants#index'
   get '/admin/merchants/:id', to: 'admin/merchants#show'
+  get '/admin/merchants/:id/edit', to: 'admin/merchants#edit'
 
   # get '/merchants/:id/invoices', to: 'merchant_invoices#index'
   get '/merchants/:merchant_id/invoices/:id', to: 'merchant_invoices#show'

--- a/db/migrate/20220414170647_add_status_to_merchants.rb
+++ b/db/migrate/20220414170647_add_status_to_merchants.rb
@@ -1,0 +1,5 @@
+class AddStatusToMerchants < ActiveRecord::Migration[5.2]
+  def change
+    add_column :merchants, :status, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_11_230225) do
+ActiveRecord::Schema.define(version: 2022_04_14_170647) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -57,6 +57,7 @@ ActiveRecord::Schema.define(version: 2022_04_11_230225) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status"
   end
 
   create_table "transactions", force: :cascade do |t|

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -21,9 +21,9 @@ RSpec.describe "Admin Merchants Index Page" do
       visit "/admin/merchants"
       # save_and_open_page
 
-      within "#merchant-#{merch1.id}" do
-        expect(page).to have_content('Lord Eldens')
-      end
+      # within "#merchant-#{merch1.id}" do
+      #   expect(page).to have_content('Lord Eldens')
+      # end
       expect(page).to have_content("Jeffs GoldBlooms")
       expect(page).to have_content("Souls Darkery")
       expect(page).to have_content("My Dog Skeeter")
@@ -41,7 +41,7 @@ RSpec.describe "Admin Merchants Index Page" do
       merch7 = Merchant.create!(name: 'Brisket is Tasty', created_at: Time.now, updated_at: Time.now, status: 0)
 
       visit "/admin/merchants"
-
+      save_and_open_page
       within "#enabled_merchants" do
         expect(page).to have_content("Lord Eldens")
         expect(page).to have_content("Souls Darkery")
@@ -57,8 +57,6 @@ RSpec.describe "Admin Merchants Index Page" do
         expect(page).to have_content("Cheese Company")
         expect(page).to_not have_content("Lord Eldens")
       end
-
-
     end
 
 

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Admin Merchants Index Page" do
       merch5 = Merchant.create!(name: 'Corgi Town', created_at: date5, updated_at: date5, status: 0)
 
       visit "/admin/merchants"
-
+      save_and_open_page
       expect(page).to have_content('Lord Eldens')
       expect(page).to have_content("Jeffs GoldBlooms")
       expect(page).to have_content("Souls Darkery")

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -19,8 +19,11 @@ RSpec.describe "Admin Merchants Index Page" do
       merch5 = Merchant.create!(name: 'Corgi Town', created_at: date5, updated_at: date5, status: 0)
 
       visit "/admin/merchants"
-      save_and_open_page
-      expect(page).to have_content('Lord Eldens')
+      # save_and_open_page
+
+      within "#merchant-#{merch1.id}" do
+        expect(page).to have_content('Lord Eldens')
+      end
       expect(page).to have_content("Jeffs GoldBlooms")
       expect(page).to have_content("Souls Darkery")
       expect(page).to have_content("My Dog Skeeter")

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+
+RSpec.describe "Admin Merchants Index Page" do
+
+  describe 'As a Visitor' do
+
+    it 'I see the name of each merchant in the system' do
+
+      date1 = "2020-02-08 09:54:09 UTC".to_datetime
+      date2 = "2017-03-16 04:04:09 UTC".to_datetime
+      date3 = "2012-08-07 01:44:09 UTC".to_datetime
+      date4 = "2015-05-03 08:23:09 UTC".to_datetime
+      date5 = "2021-01-11 12:55:09 UTC".to_datetime
+      merch1 = Merchant.create!(name: 'Lord Eldens', created_at: date1, updated_at: date1, status: 0)
+      merch2 = Merchant.create!(name: 'Jeffs GoldBlooms', created_at: date2, updated_at: date2, status: 1)
+      merch3 = Merchant.create!(name: 'Souls Darkery', created_at: date3, updated_at: date3, status: 0)
+      merch4 = Merchant.create!(name: 'My Dog Skeeter', created_at: date4, updated_at: date4, status: 1)
+      merch5 = Merchant.create!(name: 'Corgi Town', created_at: date5, updated_at: date5, status: 0)
+
+      visit "/admin/merchants"
+
+      expect(page).to have_content('Lord Eldens')
+      expect(page).to have_content("Jeffs GoldBlooms")
+      expect(page).to have_content("Souls Darkery")
+      expect(page).to have_content("My Dog Skeeter")
+      expect(page).to have_content("Corgi Town")
+
+    end
+
+
+
+
+  end
+
+end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "Admin Merchants Index Page" do
       merch2 = Merchant.create!(name: 'Jeffs GoldBlooms', created_at: Time.now, updated_at: Time.now, status: 1)
       merch3 = Merchant.create!(name: 'Souls Darkery', created_at: Time.now, updated_at: Time.now, status: 0)
       visit "/admin/merchants"
-
+      save_and_open_page
       within "#enabled_merchants-#{merch1.id}" do
         expect(page).to have_link("#{merch1.name}")
       end
@@ -82,6 +82,8 @@ RSpec.describe "Admin Merchants Index Page" do
       within "#enabled_merchants-#{merch3.id}" do
         expect(page).to have_link("#{merch3.name}")
       end
+      click_on "#{merch3.name}"
+      expect(current_path).to eq("/admin/merchants/#{merch3.id}")
     end
 
 

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -73,7 +73,15 @@ RSpec.describe "Admin Merchants Index Page" do
       merch3 = Merchant.create!(name: 'Souls Darkery', created_at: Time.now, updated_at: Time.now, status: 0)
       visit "/admin/merchants"
 
-      # within "#merchant"
+      within "#enabled_merchants-#{merch1.id}" do
+        expect(page).to have_link("#{merch1.name}")
+      end
+      within "#disabled_merchants-#{merch2.id}" do
+        expect(page).to have_link("#{merch2.name}")
+      end
+      within "#enabled_merchants-#{merch3.id}" do
+        expect(page).to have_link("#{merch3.name}")
+      end
     end
 
 

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "Admin Merchants Index Page" do
       merch2 = Merchant.create!(name: 'Jeffs GoldBlooms', created_at: Time.now, updated_at: Time.now, status: 1)
       merch3 = Merchant.create!(name: 'Souls Darkery', created_at: Time.now, updated_at: Time.now, status: 0)
       visit "/admin/merchants"
-      save_and_open_page
+      # save_and_open_page
       within "#enabled_merchants-#{merch1.id}" do
         expect(page).to have_link("#{merch1.name}")
       end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -31,6 +31,36 @@ RSpec.describe "Admin Merchants Index Page" do
 
     end
 
+    it 'I see a section for enabled/disabled merchants, each merchant in appropriate section' do
+      merch1 = Merchant.create!(name: 'Lord Eldens', created_at: Time.now, updated_at: Time.now, status: 0)
+      merch2 = Merchant.create!(name: 'Jeffs GoldBlooms', created_at: Time.now, updated_at: Time.now, status: 1)
+      merch3 = Merchant.create!(name: 'Souls Darkery', created_at: Time.now, updated_at: Time.now, status: 0)
+      merch4 = Merchant.create!(name: 'My Dog Skeeter', created_at: Time.now, updated_at: Time.now, status: 1)
+      merch5 = Merchant.create!(name: 'Corgi Town', created_at: Time.now, updated_at: Time.now, status: 0)
+      merch6 = Merchant.create!(name: 'Cheese Company', created_at: Time.now, updated_at: Time.now, status: 1)
+      merch7 = Merchant.create!(name: 'Brisket is Tasty', created_at: Time.now, updated_at: Time.now, status: 0)
+
+      visit "/admin/merchants"
+
+      within "#enabled_merchants" do
+        expect(page).to have_content("Lord Eldens")
+        expect(page).to have_content("Souls Darkery")
+        expect(page).to have_content("Corgi Town")
+        expect(page).to have_content("Brisket is Tasty")
+        expect(page).to_not have_content("Cheese Company")
+
+      end
+
+      within "#disabled_merchants" do
+        expect(page).to have_content("Jeffs GoldBlooms")
+        expect(page).to have_content("My Dog Skeeter")
+        expect(page).to have_content("Cheese Company")
+        expect(page).to_not have_content("Lord Eldens")
+      end
+
+
+    end
+
 
 
 

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -41,22 +41,39 @@ RSpec.describe "Admin Merchants Index Page" do
       merch7 = Merchant.create!(name: 'Brisket is Tasty', created_at: Time.now, updated_at: Time.now, status: 0)
 
       visit "/admin/merchants"
-      save_and_open_page
-      within "#enabled_merchants" do
+      # Enabled Merchants Section
+      within "#enabled_merchants-#{merch1.id}" do
         expect(page).to have_content("Lord Eldens")
+      end
+      within "#enabled_merchants-#{merch3.id}" do
         expect(page).to have_content("Souls Darkery")
+      end
+      within "#enabled_merchants-#{merch5.id}" do
         expect(page).to have_content("Corgi Town")
+      end
+      within "#enabled_merchants-#{merch7.id}" do
         expect(page).to have_content("Brisket is Tasty")
-        expect(page).to_not have_content("Cheese Company")
-
       end
 
-      within "#disabled_merchants" do
+      # Disabled Merchants Section
+      within "#disabled_merchants-#{merch2.id}" do
         expect(page).to have_content("Jeffs GoldBlooms")
-        expect(page).to have_content("My Dog Skeeter")
-        expect(page).to have_content("Cheese Company")
-        expect(page).to_not have_content("Lord Eldens")
       end
+      within "#disabled_merchants-#{merch4.id}" do
+        expect(page).to have_content("My Dog Skeeter")
+      end
+      within "#disabled_merchants-#{merch6.id}" do
+        expect(page).to have_content("Cheese Company")
+      end
+    end
+
+    it 'each merchants name is a link to their admin/merchants show page' do
+      merch1 = Merchant.create!(name: 'Lord Eldens', created_at: Time.now, updated_at: Time.now, status: 0)
+      merch2 = Merchant.create!(name: 'Jeffs GoldBlooms', created_at: Time.now, updated_at: Time.now, status: 1)
+      merch3 = Merchant.create!(name: 'Souls Darkery', created_at: Time.now, updated_at: Time.now, status: 0)
+      visit "/admin/merchants"
+
+      # within "#merchant"
     end
 
 

--- a/spec/features/admin/merchants/show_spec.rb
+++ b/spec/features/admin/merchants/show_spec.rb
@@ -26,7 +26,26 @@ RSpec.describe "Admin Merchants Show Page" do
 
         # expect(page).to have_content("#{merch1.name}")
       end
+    end
 
-  end
+    describe "clicking the submit button I am redirected back to the merchant show page" do
+
+      it 'I see the updated info as well as a flash message stating it was succesful' do
+        merch1 = Merchant.create!(name: 'Cheese Company', created_at: Time.now, updated_at: Time.now, status: 1)
+        visit "/admin/merchants/#{merch1.id}"
+        within "#update_this_merchant" do
+          expect(page).to have_link("Update This Merchant")
+        end
+        click_on "Update This Merchant"
+
+        fill_in "Name", with: "Holy Mackerels"
+        click_on "Submit"
+        expect(current_path).to eq("/admin/merchants/#{merch1.id}")
+        expect(page).to have_content("Holy Mackerels")
+        expect(page).to have_content("Update Succesful!")
+      end
+
+    end
+
   end
 end

--- a/spec/features/admin/merchants/show_spec.rb
+++ b/spec/features/admin/merchants/show_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe "Admin Merchants Show Page" do
 
         fill_in "Name", with: "Holy Mackerels"
         click_on "Submit"
+        save_and_open_page
         expect(current_path).to eq("/admin/merchants/#{merch1.id}")
         expect(page).to have_content("Holy Mackerels")
         expect(page).to have_content("Update Succesful!")

--- a/spec/features/admin/merchants/show_spec.rb
+++ b/spec/features/admin/merchants/show_spec.rb
@@ -9,9 +9,20 @@ RSpec.describe "Admin Merchants Show Page" do
       merch1 = Merchant.create!(name: 'Cheese Company', created_at: Time.now, updated_at: Time.now, status: 1)
 
       visit "/admin/merchants/#{merch1.id}"
-      save_and_open_page
+      # save_and_open_page
       expect(page).to have_content("Merchant Name: Cheese Company")
+    end
 
+    it 'Has a link to a page to edit this merchants information, a form is filled with existing info' do
+      merch1 = Merchant.create!(name: 'Cheese Company', created_at: Time.now, updated_at: Time.now, status: 1)
+
+      visit "/admin/merchants/#{merch1.id}"
+
+      within "#update_this_merchant" do
+        expect(page).to have_link("Update This Merchant")
+      end
+      click_on "Update This Merchant"
+      expect(current_path).to eq("/admin/merchants/#{merch1.id}/edit")
     end
 
 

--- a/spec/features/admin/merchants/show_spec.rb
+++ b/spec/features/admin/merchants/show_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+
+RSpec.describe "Admin Merchants Show Page" do
+
+  describe 'As a Visitor' do
+
+    it 'I see the name of the merchant' do
+      merch1 = Merchant.create!(name: 'Cheese Company', created_at: Time.now, updated_at: Time.now, status: 1)
+
+      visit "/admin/merchants/#{merch1.id}"
+      save_and_open_page
+      expect(page).to have_content("Merchant Name: Cheese Company")
+
+    end
+
+
+  end
+end

--- a/spec/features/admin/merchants/show_spec.rb
+++ b/spec/features/admin/merchants/show_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "Admin Merchants Show Page" do
 
         fill_in "Name", with: "Holy Mackerels"
         click_on "Submit"
-        save_and_open_page
+        # save_and_open_page
         expect(current_path).to eq("/admin/merchants/#{merch1.id}")
         expect(page).to have_content("Holy Mackerels")
         expect(page).to have_content("Update Succesful!")

--- a/spec/features/admin/merchants/show_spec.rb
+++ b/spec/features/admin/merchants/show_spec.rb
@@ -12,19 +12,21 @@ RSpec.describe "Admin Merchants Show Page" do
       # save_and_open_page
       expect(page).to have_content("Merchant Name: Cheese Company")
     end
+    describe 'Merchant Show has link to edit merchants info' do
+      it 'click the link and I am taken to an edit page with a form containg current attributes' do
+        merch1 = Merchant.create!(name: 'Cheese Company', created_at: Time.now, updated_at: Time.now, status: 1)
 
-    it 'Has a link to a page to edit this merchants information, a form is filled with existing info' do
-      merch1 = Merchant.create!(name: 'Cheese Company', created_at: Time.now, updated_at: Time.now, status: 1)
+        visit "/admin/merchants/#{merch1.id}"
 
-      visit "/admin/merchants/#{merch1.id}"
+        within "#update_this_merchant" do
+          expect(page).to have_link("Update This Merchant")
+        end
+        click_on "Update This Merchant"
+        expect(current_path).to eq("/admin/merchants/#{merch1.id}/edit")
 
-      within "#update_this_merchant" do
-        expect(page).to have_link("Update This Merchant")
+        # expect(page).to have_content("#{merch1.name}")
       end
-      click_on "Update This Merchant"
-      expect(current_path).to eq("/admin/merchants/#{merch1.id}/edit")
-    end
 
-
+  end
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -162,12 +162,5 @@ RSpec.describe Merchant, type: :model do
       merch7 = Merchant.create!(name: 'Brisket is Tasty', created_at: date7, updated_at: date7, status: 0)
       expect(Merchant.status_disabled).to eq([merch2, merch4, merch6])
     end
-
-
-
-
-
-
-
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe Merchant, type: :model do
       expect(merch1.total_revenue_for_invoice(invoice1.id)).to eq(4167.88)
     end
 
-    xit '#status_enabled returns all merchants with the status: enabled (0)' do
+    it '#status_enabled returns all merchants with the status: enabled (0)' do
       date1 = "2020-02-08 09:54:09 UTC".to_datetime
       date2 = "2017-03-16 04:04:09 UTC".to_datetime
       date3 = "2012-08-07 01:44:09 UTC".to_datetime
@@ -136,12 +136,12 @@ RSpec.describe Merchant, type: :model do
       date6 = "2016-08-18 02:36:09 UTC".to_datetime
       date7 = "2016-11-18 02:36:09 UTC".to_datetime
       merch1 = Merchant.create!(name: 'Lord Eldens', created_at: date1, updated_at: date1, status: 0)
-      merch2 = Merchant.create!(name: 'Lord Eldens', created_at: date2, updated_at: date2, status: 1)
-      merch3 = Merchant.create!(name: 'Lord Eldens', created_at: date3, updated_at: date3, status: 0)
-      merch4 = Merchant.create!(name: 'Lord Eldens', created_at: date4, updated_at: date4, status: 1)
-      merch5 = Merchant.create!(name: 'Lord Eldens', created_at: date5, updated_at: date5, status: 0)
-      merch6 = Merchant.create!(name: 'Lord Eldens', created_at: date5, updated_at: date6, status: 1)
-      merch7 = Merchant.create!(name: 'Lord Eldens', created_at: date7, updated_at: date7, status: 0)
+      merch2 = Merchant.create!(name: 'Jeffs GoldBlooms', created_at: date2, updated_at: date2, status: 1)
+      merch3 = Merchant.create!(name: 'Souls Darkery', created_at: date3, updated_at: date3, status: 0)
+      merch4 = Merchant.create!(name: 'My Dog Skeeter', created_at: date4, updated_at: date4, status: 1)
+      merch5 = Merchant.create!(name: 'Corgi Town', created_at: date5, updated_at: date5, status: 0)
+      merch6 = Merchant.create!(name: 'Cheese Company', created_at: date5, updated_at: date6, status: 1)
+      merch7 = Merchant.create!(name: 'Brisket is Tasty', created_at: date7, updated_at: date7, status: 0)
 
       expect(Merchant.status_enabled).to eq([merch1, merch3, merch5, merch7])
     end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -127,6 +127,25 @@ RSpec.describe Merchant, type: :model do
       expect(merch1.total_revenue_for_invoice(invoice1.id)).to eq(4167.88)
     end
 
+    xit '#status_enabled returns all merchants with the status: enabled (0)' do
+      date1 = "2020-02-08 09:54:09 UTC".to_datetime
+      date2 = "2017-03-16 04:04:09 UTC".to_datetime
+      date3 = "2012-08-07 01:44:09 UTC".to_datetime
+      date4 = "2015-05-03 08:23:09 UTC".to_datetime
+      date5 = "2021-01-11 12:55:09 UTC".to_datetime
+      date6 = "2016-08-18 02:36:09 UTC".to_datetime
+      date7 = "2016-11-18 02:36:09 UTC".to_datetime
+      merch1 = Merchant.create!(name: 'Lord Eldens', created_at: date1, updated_at: date1, status: 0)
+      merch2 = Merchant.create!(name: 'Lord Eldens', created_at: date2, updated_at: date2, status: 1)
+      merch3 = Merchant.create!(name: 'Lord Eldens', created_at: date3, updated_at: date3, status: 0)
+      merch4 = Merchant.create!(name: 'Lord Eldens', created_at: date4, updated_at: date4, status: 1)
+      merch5 = Merchant.create!(name: 'Lord Eldens', created_at: date5, updated_at: date5, status: 0)
+      merch6 = Merchant.create!(name: 'Lord Eldens', created_at: date5, updated_at: date6, status: 1)
+      merch7 = Merchant.create!(name: 'Lord Eldens', created_at: date7, updated_at: date7, status: 0)
+
+      expect(Merchant.status_enabled).to eq([merch1, merch3, merch5, merch7])
+    end
+
 
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -142,9 +142,31 @@ RSpec.describe Merchant, type: :model do
       merch5 = Merchant.create!(name: 'Corgi Town', created_at: date5, updated_at: date5, status: 0)
       merch6 = Merchant.create!(name: 'Cheese Company', created_at: date5, updated_at: date6, status: 1)
       merch7 = Merchant.create!(name: 'Brisket is Tasty', created_at: date7, updated_at: date7, status: 0)
-
       expect(Merchant.status_enabled).to eq([merch1, merch3, merch5, merch7])
     end
+
+    it '#status_disabled returns all merchants with the status: disabled (1)' do
+      date1 = "2020-02-08 09:54:09 UTC".to_datetime
+      date2 = "2017-03-16 04:04:09 UTC".to_datetime
+      date3 = "2012-08-07 01:44:09 UTC".to_datetime
+      date4 = "2015-05-03 08:23:09 UTC".to_datetime
+      date5 = "2021-01-11 12:55:09 UTC".to_datetime
+      date6 = "2016-08-18 02:36:09 UTC".to_datetime
+      date7 = "2016-11-18 02:36:09 UTC".to_datetime
+      merch1 = Merchant.create!(name: 'Lord Eldens', created_at: date1, updated_at: date1, status: 0)
+      merch2 = Merchant.create!(name: 'Jeffs GoldBlooms', created_at: date2, updated_at: date2, status: 1)
+      merch3 = Merchant.create!(name: 'Souls Darkery', created_at: date3, updated_at: date3, status: 0)
+      merch4 = Merchant.create!(name: 'My Dog Skeeter', created_at: date4, updated_at: date4, status: 1)
+      merch5 = Merchant.create!(name: 'Corgi Town', created_at: date5, updated_at: date5, status: 0)
+      merch6 = Merchant.create!(name: 'Cheese Company', created_at: date5, updated_at: date6, status: 1)
+      merch7 = Merchant.create!(name: 'Brisket is Tasty', created_at: date7, updated_at: date7, status: 0)
+      expect(Merchant.status_disabled).to eq([merch2, merch4, merch6])
+    end
+
+
+
+
+
 
 
   end


### PR DESCRIPTION
In this PR:
- Created the admin/merchants index page
- Page is sorted by enabled and disabled merchants
        - this was done by created class methods in the merchant model for returning all merchants with the enabled status and another for returning all merchants with 'disabled' status
- Created the admin/merchants/:id show page
- Show page has a link to the admin/merchants/:id/edit page to fill out a form updating the merchant
- Updating the merchant redirects back to the merchants show page and displays a flash message for a successful update