### PR TITLE
fixed deprecation warning

### DIFF
--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -70,7 +70,7 @@ class Merchant < ApplicationRecord
   def self.top_5_by_revenue
     joins(invoices: [:transactions, :invoice_items])
     .where(transactions: {result: 0})
-    .order("sum(invoice_items.quantity * invoice_items.unit_price) DESC")
+    .order(Arel.sql("sum(invoice_items.quantity * invoice_items.unit_price) DESC"))
     .group(:id)
     .limit(5)
   end

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe 'the admin invoice show page' do
     expect(page).to have_content("Created: #{invoice_1.formatted_created_at}")
     expect(page).to have_content("Customer First Name: #{customer_1.first_name}")
     expect(page).to have_content("Customer Last Name: #{customer_1.last_name}")
+  end
 
   describe 'As an Admin' do
     before do


### PR DESCRIPTION
**Previous warning:** DEPRECATION WARNING: Dangerous query method (method whose arguments are used as raw SQL) called with non-attribute argument(s): "sum(invoice_items.quantity * invoice_items.unit_price) DESC". Non-attribute arguments will be disallowed in Rails 6.0. This method should not be called with user-provided values, such as request parameters or model attributes. Known-safe values can be passed by wrapping them in Arel.sql(). (called from top_5_by_revenue at /Users/andrewspeth/turing/2module/projects/little-esty-shop/app/models/merchant.rb:73)

Fixed by wrapping arguments in Arel.sql()
There are a number of articles about this issue, here's one I liked: https://www.bigbinary.com/blog/rails-5-2-disallows-raw-sql-in-active-record