### PR TITLE
Top merchants part 2

### DIFF
--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -67,10 +67,12 @@ class Merchant < ApplicationRecord
   end
 
   def self.top_5_by_revenue
-    joins(invoices: [:transactions, :invoice_items])
+    joins(:invoices, [:transactions, :invoice_items])
     .where(transactions: {result: 0})
-    .order(Arel.sql("sum(invoice_items.quantity * invoice_items.unit_price) DESC"))
+    .select("merchants.*, sum(invoice_items.quantity * invoice_items.unit_price) AS total_revenue")
     .group(:id)
+    .order('total_revenue DESC')
     .limit(5)
-  end
+  end 
+  
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -69,7 +69,7 @@ class Merchant < ApplicationRecord
   def self.top_5_by_revenue
     joins(:invoices, [:transactions, :invoice_items])
     .where(transactions: {result: 0})
-    .select("merchants.*, sum(invoice_items.quantity * invoice_items.unit_price) AS total_revenue")
+    .select("merchants.*, sum(invoice_items.quantity * invoice_items.unit_price / 100.00) AS total_revenue")
     .group(:id)
     .order('total_revenue DESC')
     .limit(5)

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -35,6 +35,7 @@
 <section id="top_five_merchant-<%= merchant.id %>">
 
   <%= link_to "#{merchant.name}", "/admin/merchants/#{merchant.id}" %><br>
+  Total Revenue: $<%= "%.2f" % merchant.total_revenue%>
 
 <section>
 <% end %>

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe "Admin Merchants Index Page" do
 
     describe 'Top 5 Merchants by revenue are shown' do
       
-      it 'I see the name of each merchant, and a link to their show page' do
+      it 'I see the name of each merchant, their total revenue, and a link to their show page' do
 
         merchant_1 = Merchant.create!(name: 'Lord Eldens', created_at: Time.now, updated_at: Time.now)
         item_1 = create(:item, name: 'Elden Ring', unit_price: 9999, merchant_id: merchant_1.id)
@@ -167,36 +167,40 @@ RSpec.describe "Admin Merchants Index Page" do
           expect("My Dog Skeeter").to appear_before("Lord Eldens")
           expect("Lord Eldens").to appear_before("Jeffs GoldBlooms")
           expect("Jeffs GoldBlooms").to appear_before("Souls Darkery")
+          expect(page).to_not have_content("Corgi Town")
         end
 
         within "#top_five_merchant-#{merchant_6.id}" do
           expect(page).to have_link("Cheese Company")
+          expect(page).to have_content("Total Revenue: $18175.20")
         end
 
         within "#top_five_merchant-#{merchant_4.id}" do
           expect(page).to have_link("My Dog Skeeter")
+          expect(page).to have_content("Total Revenue: $123.45")
         end
 
         within "#top_five_merchant-#{merchant_1.id}" do
           expect(page).to have_link("Lord Eldens")
+          expect(page).to have_content("Total Revenue: $99.99")
         end
 
         within "#top_five_merchant-#{merchant_2.id}" do
           expect(page).to have_link("Jeffs GoldBlooms")
+          expect(page).to have_content("Total Revenue: $88.88")
+
         end
 
         within "#top_five_merchant-#{merchant_3.id}" do
+          expect(page).to have_content("Total Revenue: $77.77")
           click_link "Souls Darkery"
+
         end
         expect(current_path).to eq("/admin/merchants/#{merchant_3.id}")
 
       end
 
     end
-
-
-
-
   end
 
 end


### PR DESCRIPTION
In this PR:

- refactored the Merchant class method self.top_5_by_revenue method to use the alias total_revenue
- this alias is then called in the admin/merchants index page view so that next to each merchant in the top 5 merchants section, the merchants total revenue is displayed
- added expectations to the top 5 merchants test to test that the correct merchants are being displayed with their total revenue, and sad path testing in the same test
- all tests passing 
- user story #11 is now complete